### PR TITLE
add samtools as utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
+## makes a container with Strelka installed plus bcftools and samtools as utilities
 FROM fredhutch/bcftools:1.9
 
-RUN apt-get update -y && apt-get install -y curl build-essential bzip2 gcc g++ make python zlib1g-dev
 
+RUN apt-get update -y && apt-get install -y curl build-essential bzip2 gcc g++ make python zlib1g-dev wget libncurses5-dev
 
 RUN curl -LO https://github.com/Illumina/strelka/archive/v2.9.10.tar.gz
 
@@ -18,4 +19,12 @@ RUN ../configure --jobs=4 && make -j4 install
 WORKDIR /
 
 RUN rm -rf strelka-2.9.10 v2.9.10.tar.gz
+
+## Install samtools 1.10
+RUN wget https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2 && \
+	tar jxf samtools-1.10.tar.bz2 && \
+	rm samtools-1.10.tar.bz2 && \
+	cd samtools-1.10 && \
+	make 
+ENV PATH=${PATH}:/samtools-1.10
 


### PR DESCRIPTION
The task I used this container for ended up needing samtools as a utility.  I added that and rebuilt it and it works a-ok.  I thought I'd request these changes in your repo, and then will also attempt to push this latest version to: `fredhutch/strelka:2.9.10-samtools` instead of `fredhutch/strelka:2.9.10` which is up there now.  That way if anyone was using it without samtools, they can keep doing so. ;). 
